### PR TITLE
Use ncompress for LZW decompression

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Second, you should do a pip install in your terminal of `Martin Valgur's Pythoni
 
     pip install hatanaka
 
-The Hatanaka library in Python was kindly contributed by Martin Valgur in v1.1, and replaces the older "RNX2CRX" (and GZIP, thanks to the unlzw3 library) which are Windows-only executables, making the (de)compression possible across all platforms.
+The Hatanaka library in Python was kindly contributed by Martin Valgur in v1.1, and replaces the older "RNX2CRX" (and GZIP, thanks to the ncompress library) which are Windows-only executables, making the (de)compression possible across all platforms.
 
 The user can then run the application by running **'leogps.py'**, in the main directory, and you should see the LEOGPS GUI launch:
 

--- a/docs/docs_install.rst
+++ b/docs/docs_install.rst
@@ -35,6 +35,6 @@ The Hatanaka library in Python was kindly contributed by Martin Valgur in v1.1, 
 That's it! No further setup is needed, unless you need any of the other package dependencies.
 
 .. note:: Package dependencies include: 
-   copy, datetime, decimal, hatanaka, math, matplotlib, numpy, os, pathlib, PIL, tkinter, unlzw3, urllib, warnings
+   copy, datetime, decimal, hatanaka, math, matplotlib, numpy, os, pathlib, PIL, tkinter, ncompress, urllib, warnings
 
 Next, we will run and explain the setup behind the default native scenario packaged in LEOGPS - a formation flying scenario at ~200km in-track baseline of the GRACE mission.

--- a/source/gpsxtr.py
+++ b/source/gpsxtr.py
@@ -47,7 +47,7 @@ import warnings
 import numpy as np
 import urllib.request
 from pathlib import Path
-from unlzw3 import unlzw
+from ncompress import decompress as unlzw
 
 # Import local libraries
 from source import pubplt


### PR DESCRIPTION
Hello again,
This PR is a small follow-up to #2, which replaces the unlzw3 LZW (.Z file) decompression with the new [ncompress](https://github.com/valgur/ncompress) library. It's about 40x faster than unlzw3, which is quite noticeable when some of the 10 MB RINEX files take multiple seconds to decompress with unlzw3, and it's already installed transitively with hatanaka anyway.