### PR TITLE
Add for cross-compatibility on Linux (tested on Ubuntu 18.04).

### DIFF
--- a/source/gpsxtr.py
+++ b/source/gpsxtr.py
@@ -88,7 +88,7 @@ def gpsxtr(inps, tstart, tstop, tstep):
     
     # We will download them into our directories, below, later on.
     cwd = inps['cwd'] # Get current main working directory
-    iwd = cwd + '\\input\\' # Get directory for ephemeris / clock files
+    iwd = cwd + os.sep + "input" + os.sep # Get directory for ephemeris / clock files
     os.chdir(cwd) # Ensure the user is running in the main directory.
     
     # Then, we must retrieve all number of days of GPS and CLK data needed    

--- a/source/leogui.py
+++ b/source/leogui.py
@@ -29,8 +29,10 @@ from os.path import dirname, abspath, join
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
-
+from pathlib import Path
+import os
 # Import local libraries
+
 from source import leorun
 
 class RunGUI:
@@ -130,8 +132,8 @@ class RunGUI:
         
         # Define the path to the LEOGPS logo file.
         leogps_logo = dirname(dirname(abspath(__file__)))
-        leogps_logo = leogps_logo + '\docs\_static\leogps_logo.png'
-        
+        leogps_logo = leogps_logo + os.sep + 'docs' + os.sep + '_static' + os.sep + 'leogps_logo.png'
+        print(leogps_logo)
         # Get the users current screen height.
         screen_height = master.winfo_screenheight()
         

--- a/source/pubplt.py
+++ b/source/pubplt.py
@@ -25,7 +25,7 @@
 import datetime
 import matplotlib.pyplot as plt
 from decimal import Decimal
-
+import os
 def gps_report(gpsdata, goodsats, inps):
     '''Generates an ASCII text report of GPS position, velocity, and clock
     bias (ITRF). Report will be saved in the `output/gps_report` folder.
@@ -48,7 +48,7 @@ def gps_report(gpsdata, goodsats, inps):
     
     cwd = inps['cwd'] # Get current main working directory
     
-    file_path = open(cwd+'\\output\\gps_report\\GPS_Report.txt', 'w')
+    file_path = open(cwd+ os.sep + 'output' + os.sep + 'gps_report' +  os.sep +'GPS_Report.txt', 'w')
     
     line = 'G         '
     line += 'Pos_X (km)       '
@@ -183,7 +183,7 @@ def gps_graphs(SV, t_usr_dt, t_usr_ss, gpsdata, inps):
     
     # Tight-spaced plot
     plt.tight_layout()
-    plt.savefig(cwd + '\\output\\gps_plots\\GPS_SV' + str(SV) + '_PVT.png')
+    plt.savefig(cwd + os.sep + 'output' + os.sep + 'gps_plots' + os.sep + 'GPS_SV' + str(SV) + '_PVT.png')
     
     # Close this figure
     plt.close(fig)
@@ -220,7 +220,7 @@ def leo_results(results, inps):
     frameOrb = inps['frameOrb']
     frameForm = inps['frameForm']
     
-    file_path = open(cwd+'\\output\\LEOGPS_Results.txt', 'w')
+    file_path = open(cwd+ os.sep + 'output' + os.sep + 'LEOGPS_Results.txt', 'w')
     
     line  = 'Date       '
     line += 'Time      '
@@ -315,6 +315,6 @@ def leo_results(results, inps):
     file_path.close()
     
     print('Completed processing in LEOGPS! Output file stored:')
-    print(cwd+'\\output\\LEOGPS_Results.txt \n')
+    print(cwd + os.sep + 'output'+ os.sep + 'LEOGPS_Results.txt \n')
     
     return None


### PR DESCRIPTION
Previous usage of '\\' character conflicts with UNIX file format. Used os.sep to delineate file path for both Linux and windows ( likely MacOS as well) . 