### PR TITLE
Added functionality to save to a relative file path. 

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -22,16 +22,16 @@
 
 ~:
 ~: Input the 4-letter ID of the first spacecraft (i.e. LEOA)
-I: name1 VEHA
+I: name1 GRCA
 ~:
 ~: Input the 4-letter ID of the second spacecraft (i.e. LEOB)
-I: name2 VEHC
+I: name2 GRCB
 ~: 
 ~: Input the starting epoch in YYYY-MM-DD-HH-MN-SS (i.e. 1980-12-31-01-45-00)
-I: dtstart 2018-10-16-07-30-00
+I: dtstart 2010-07-27-06-30-00
 ~:
 ~: Input the ending epoch in YYYY-MM-DD-HH-MN-SS (i.e. 1980-12-31-03-45-00)
-I: dtstop 2018-10-16-10-30-00
+I: dtstop 2010-07-27-18-30-00
 ~: 
 ~: Input the timestep in seconds (i.e. 30)
 I: timestep 1

--- a/config/config.txt
+++ b/config/config.txt
@@ -19,21 +19,22 @@
 ##                                                                           ##
 ###############################################################################
 ###############################################################################
+
 ~:
 ~: Input the 4-letter ID of the first spacecraft (i.e. LEOA)
-I: name1 GRCA
+I: name1 VEHA
 ~:
 ~: Input the 4-letter ID of the second spacecraft (i.e. LEOB)
-I: name2 GRCB
+I: name2 VEHC
 ~: 
 ~: Input the starting epoch in YYYY-MM-DD-HH-MN-SS (i.e. 1980-12-31-01-45-00)
-I: dtstart 2010-07-27-06-30-00
+I: dtstart 2018-10-16-07-30-00
 ~:
 ~: Input the ending epoch in YYYY-MM-DD-HH-MN-SS (i.e. 1980-12-31-03-45-00)
-I: dtstop 2010-07-27-18-30-00
+I: dtstop 2018-10-16-10-30-00
 ~: 
 ~: Input the timestep in seconds (i.e. 30)
-I: timestep 10
+I: timestep 1
 ~: 
 ~: Input single or dual frequency processing (i.e. 1 or 2)
 I: freq 2
@@ -60,10 +61,13 @@ I: antoffsetY 0.0
 I: antoffsetZ 0.0
 ~:
 ~: Select the output orbit ephemeris coordinate frame
-I: frameOrb ICRF
+I: frameOrb ITRF
 ~:
 ~: Select the output relative baseline coordinate frame
-I: frameForm Hill
+I: frameForm ITRF
+~:
+~: Input relative file path of your input and output folders ("default" for default file path)
+I: filepath default
 ~:
 ###############################################################################
 ###############################################################################

--- a/leogps.py
+++ b/leogps.py
@@ -10,7 +10,8 @@
 ##                                    v 1.3 (Stable)                         ##
 ##                                                                           ##
 ##    Written by Samuel Y. W. Low.                                           ##
-##    Last modified 11-Sep-2021.                                             ##
+##    Added functionality by Andrew G. T. Ng                                 ##
+##    Last modified 18-Jul-2022.                                             ##
 ##    Website: https://github.com/sammmlow/LEOGPS                            ##
 ##    Documentation: https://leogps.readthedocs.io/en/latest/                ##
 ##                                                                           ##

--- a/output/gps_plots/README.txt
+++ b/output/gps_plots/README.txt
@@ -1,1 +1,0 @@
-This folder keeps all records of interpolated GPS ephemeris (XYZ positions and velocities) saved in individual plot files.

--- a/output/gps_report/README.txt
+++ b/output/gps_report/README.txt
@@ -1,1 +1,0 @@
-This folder keeps all records of interpolated GPS ephemeris (XYZ positions and velocities) saved in a text file.

--- a/source/gpsxtr.py
+++ b/source/gpsxtr.py
@@ -88,7 +88,7 @@ def gpsxtr(inps, tstart, tstop, tstep):
     
     # We will download them into our directories, below, later on.
     cwd = inps['cwd'] # Get current main working directory
-    iwd = cwd + '\\input\\' # Get directory for ephemeris / clock files
+    iwd = cwd + os.sep + "input" + os.sep # Get directory for ephemeris / clock files
     os.chdir(cwd) # Ensure the user is running in the main directory.
     
     # Then, we must retrieve all number of days of GPS and CLK data needed    

--- a/source/gpsxtr.py
+++ b/source/gpsxtr.py
@@ -88,7 +88,7 @@ def gpsxtr(inps, tstart, tstop, tstep):
     
     # We will download them into our directories, below, later on.
     cwd = inps['cwd'] # Get current main working directory
-    iwd = cwd + os.sep + "input" + os.sep # Get directory for ephemeris / clock files
+    iwd = cwd +  os.sep + "input"  + os.sep + inps['filepath'] + os.sep # Get directory for ephemeris / clock files
     os.chdir(cwd) # Ensure the user is running in the main directory.
     
     # Then, we must retrieve all number of days of GPS and CLK data needed    

--- a/source/leogui.py
+++ b/source/leogui.py
@@ -29,8 +29,10 @@ from os.path import dirname, abspath, join
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
-
+from pathlib import Path
+import os
 # Import local libraries
+
 from source import leorun
 
 class RunGUI:
@@ -130,8 +132,8 @@ class RunGUI:
         
         # Define the path to the LEOGPS logo file.
         leogps_logo = dirname(dirname(abspath(__file__)))
-        leogps_logo = leogps_logo + '\docs\_static\leogps_logo.png'
-        
+        leogps_logo = leogps_logo + os.sep + 'docs' + os.sep + '_static' + os.sep + 'leogps_logo.png'
+        print(leogps_logo)
         # Get the users current screen height.
         screen_height = master.winfo_screenheight()
         

--- a/source/leogui.py
+++ b/source/leogui.py
@@ -86,6 +86,7 @@ class RunGUI:
         #####################################################################
         
         # Initialise the basic text labels (found in the configuration file):
+        
         self.txt01 = 'Spacecraft A 4-letter ID (LEOA)'
         self.txt02 = 'Spacecraft B 4-letter ID (LEOB)'
         self.txt03 = 'Epoch start (YYYY-MM-DD-HH-MN-SS)'
@@ -101,8 +102,9 @@ class RunGUI:
         self.txt13 = 'GPS antenna Body-Frame Z offset (m)'
         self.txt14 = 'Absolute orbit frame (not in plot)' 
         self.txt15 = 'Relative orbit frame (default Hill)'
-        
+        self.txt16 = 'Relative file path (leave empty for default folder)'    
         # Initialise tkinter variables for the entries corresponding to above.
+        
         self.var01 = tk.StringVar() # 4-letter ID of LEO A
         self.var02 = tk.StringVar() # 4-letter ID of LEO B
         self.var03 = tk.StringVar() # Start epoch datetime
@@ -118,7 +120,7 @@ class RunGUI:
         self.var13 = tk.DoubleVar() # Antenna offset Z
         self.var14 = tk.IntVar()    # Frequency number
         self.var15 = tk.IntVar()    # Frequency number
-        
+        self.var16 = tk.StringVar()
         # Initialise an error flag to stop LEOGPS when there are bugs.
         self.error_flag = False
         
@@ -336,6 +338,15 @@ class RunGUI:
         self.entry15c.grid(row=15, column=3, padx=5, pady=2, sticky='w')
         self.errtx15 = tk.Label(master, text='', fg='red' )
         self.errtx15.grid(row=15, column=4, padx=5, pady=2, sticky='w')
+        
+        # Input relative file path
+        self.label16 = tk.Label(master, text=self.txt16 )
+        self.label16.grid(row=16, column=0, padx=40, pady=2, sticky='w')
+        self.entry16 = tk.Entry(master, width=10, textvariable=self.var16)
+        self.entry16.grid(row=16, column=1, padx=5, pady=2, sticky='w')
+        self.errtx16 = tk.Label(master, text='', fg='red' )
+        self.errtx16.grid(row=16, column=4, padx=5, pady=2, sticky='w')
+        
         
         #####################################################################
         #####################################################################
@@ -789,9 +800,25 @@ class RunGUI:
             self.entry15c.deselect()
             self.errtx15.configure(text='!')
         self.error_msgprint += errmsg
+        #####################################################################
+        #####################################################################
+        
+        
+        # 16. Check relative filepath
+        
+        self.var16.set(inps['filepath'])
+        if len(inps['filepath']) <1 or inps['filepath'] is None:
+            errmsg = 'Filepath cannot be empty'
+            self.errtx16.configure(text='!')
+        else:
+            errmsg = ''
+            self.errtx16.configure(text='')
+        self.error_msgprint += errmsg
+        
         
         #####################################################################
         #####################################################################
+        
         
         # Finally, display an error textbox if there are any error messages.
         
@@ -834,14 +861,15 @@ class RunGUI:
         # Variables to be recorded based on tkinter entries.
         var_arr = [self.var01, self.var02, self.var03, self.var04, self.var05,
                    self.var06, self.var07, self.var08, self.var09, self.var10, 
-                   self.var11, self.var12, self.var13, self.var14, self.var15]
+                   self.var11, self.var12, self.var13, self.var14, self.var15,
+                   self.var16]
         
         # Key values (to be referred).
         
         key_arr = ['name1', 'name2', 'dtstart', 'dtstop', 'timestep', 'freq',
                    'hatchfilter', 'hatchlength', 'cycsliptol', 'cycsliplen',
                    'antoffsetX', 'antoffsetY', 'antoffsetZ',
-                   'frameOrb', 'frameForm']
+                   'frameOrb', 'frameForm', 'filepath']
         
         frame_arr = ['frameOrb', 'frameForm']                   
         
@@ -1243,6 +1271,26 @@ class RunGUI:
         finally:
             self.error_msgprint += errmsg
         
+        #####################################################################
+        #####################################################################
+         # 16. Check for 4-letter ID of LEO-A
+        
+        try:
+            _v16 = self.var16.get() # Exception raised if entry is erroneous
+            if len(_v16) <1:
+                errmsg = 'Cannot be empty'
+                self.errtx01.configure(text='!')
+            else:
+                errmsg = ''
+                self.errtx01.configure(text='')
+        except:
+            _v16 = ''
+            errmsg = 'Error! Expected a string for the filepath! \n'
+            self.errtx16.configure(text='!')
+        finally:
+            self.error_msgprint += errmsg
+            
+            
         #####################################################################
         #####################################################################
         

--- a/source/leorun.py
+++ b/source/leorun.py
@@ -33,13 +33,14 @@ from source import posvel
 from source import ambest
 from source import frames
 from source import pubplt
-
+import os 
 def run():
     '''Basically runs the primary workflow for LEOGPS' relative positioning.
     No input arguments needed, and returns None.
     
     '''
-
+   
+        
     # IMPORTING USER DEFINED PARAMETERS:
     # ==================================
     # -> The routine 'inpxtr.py' extracts out all user-specified parameters.
@@ -50,6 +51,10 @@ def run():
     n1  = inps['name1'] # Name of LEO1
     n2  = inps['name2'] # Name of LEO2
 
+
+    if not os.path.exists(os.getcwd()  + os.sep +  'output' + os.sep + inps['filepath']):
+        os.makedirs(os.getcwd() + os.sep + 'output' +  os.sep + inps['filepath'])
+        
     # FINDING THE RINEX FILE PATHS:
     # =============================
     # -> The routine 'rnpath.py' will output the path of the RINEX file.

--- a/source/pubplt.py
+++ b/source/pubplt.py
@@ -25,7 +25,7 @@
 import datetime
 import matplotlib.pyplot as plt
 from decimal import Decimal
-
+import os
 def gps_report(gpsdata, goodsats, inps):
     '''Generates an ASCII text report of GPS position, velocity, and clock
     bias (ITRF). Report will be saved in the `output/gps_report` folder.
@@ -48,7 +48,7 @@ def gps_report(gpsdata, goodsats, inps):
     
     cwd = inps['cwd'] # Get current main working directory
     
-    file_path = open(cwd+'\\output\\gps_report\\GPS_Report.txt', 'w')
+    file_path = open(cwd+ os.sep + 'output' + os.sep + 'gps_report' +  os.sep +'GPS_Report.txt', 'w')
     
     line = 'G         '
     line += 'Pos_X (km)       '
@@ -183,7 +183,7 @@ def gps_graphs(SV, t_usr_dt, t_usr_ss, gpsdata, inps):
     
     # Tight-spaced plot
     plt.tight_layout()
-    plt.savefig(cwd + '\\output\\gps_plots\\GPS_SV' + str(SV) + '_PVT.png')
+    plt.savefig(cwd + os.sep + 'output' + os.sep + 'gps_plots' + os.sep + 'GPS_SV' + str(SV) + '_PVT.png')
     
     # Close this figure
     plt.close(fig)
@@ -220,7 +220,7 @@ def leo_results(results, inps):
     frameOrb = inps['frameOrb']
     frameForm = inps['frameForm']
     
-    file_path = open(cwd+'\\output\\LEOGPS_Results.txt', 'w')
+    file_path = open(cwd+ os.sep + 'output' + os.sep + 'LEOGPS_Results.txt', 'w')
     
     line  = 'Date       '
     line += 'Time      '
@@ -315,6 +315,6 @@ def leo_results(results, inps):
     file_path.close()
     
     print('Completed processing in LEOGPS! Output file stored:')
-    print(cwd+'\\output\\LEOGPS_Results.txt \n')
+    print(cwd + os.sep + 'output'+ os.sep + 'LEOGPS_Results.txt \n')
     
     return None

--- a/source/pubplt.py
+++ b/source/pubplt.py
@@ -48,7 +48,13 @@ def gps_report(gpsdata, goodsats, inps):
     
     cwd = inps['cwd'] # Get current main working directory
     
-    file_path = open(cwd+ os.sep + 'output' + os.sep + 'gps_report' +  os.sep +'GPS_Report.txt', 'w')
+    
+    full_file_path = cwd + os.sep + 'output' + os.sep + inps['filepath'] + os.sep + 'gps_report' 
+    if not os.path.exists(full_file_path):
+        os.makedirs(full_file_path)
+        
+        
+    file_path = open(full_file_path + os.sep +'GPS_Report.txt', 'w')
     
     line = 'G         '
     line += 'Pos_X (km)       '
@@ -183,7 +189,12 @@ def gps_graphs(SV, t_usr_dt, t_usr_ss, gpsdata, inps):
     
     # Tight-spaced plot
     plt.tight_layout()
-    plt.savefig(cwd + os.sep + 'output' + os.sep + 'gps_plots' + os.sep + 'GPS_SV' + str(SV) + '_PVT.png')
+    
+    parent_folder = cwd + os.sep + 'output' + os.sep + inps['filepath'] + os.sep + 'gps_plots' + os.sep
+    if not os.path.exists(parent_folder):
+        os.makedirs(parent_folder)
+        
+    plt.savefig(parent_folder + str(SV) + '_PVT.png')
     
     # Close this figure
     plt.close(fig)
@@ -220,7 +231,7 @@ def leo_results(results, inps):
     frameOrb = inps['frameOrb']
     frameForm = inps['frameForm']
     
-    file_path = open(cwd+ os.sep + 'output' + os.sep + 'LEOGPS_Results.txt', 'w')
+    file_path = open(cwd+ os.sep + 'output' + os.sep + inps['filepath'] + os.sep + 'LEOGPS_Results.txt', 'w')
     
     line  = 'Date       '
     line += 'Time      '
@@ -315,6 +326,6 @@ def leo_results(results, inps):
     file_path.close()
     
     print('Completed processing in LEOGPS! Output file stored:')
-    print(cwd + os.sep + 'output'+ os.sep + 'LEOGPS_Results.txt \n')
+    print(cwd + os.sep + inps['filepath'] + os.sep +  'output'+ os.sep + 'LEOGPS_Results.txt \n')
     
     return None

--- a/source/rnpath.py
+++ b/source/rnpath.py
@@ -42,7 +42,7 @@
 # Import global libraries
 import hatanaka
 from pathlib import Path
-
+import os
 def rnpath(inps):
     '''Gets the paths to RINEX files, following AIUB CODE's naming convention.
 
@@ -59,21 +59,21 @@ def rnpath(inps):
         Path of RINEX file of LEO-B
     
     '''
-    
+
     # Let us start by parsing out all relevant user configuration inputs.
     yy       = inps['dtstart_yy'] # The starting two-digit year number
     doy      = inps['dtstart_doy'] # The starting day of year in GPST
-    cwd      = Path(inps['cwd']) # Current working directory
-    iwd      = cwd / 'input'
+    cwd      = os.getcwd()    #(inps['cwd']) # Current working directory
+    iwd      = cwd +  os.sep + 'input' + os.sep + inps['filepath'] 
     name1    = inps['name1'] # 4-letter ID of the first spacecraft
     name2    = inps['name2'] # 4-letter ID of the second spacecraft
-
     # Now, we get all necessary file paths, in the input folder.
-    rnx1file = iwd / (name1 + doy + '0.' + yy + 'O') # pathlib Path class
-    rnx2file = iwd / (name2 + doy + '0.' + yy + 'O') # pathlib Path class
-    crx1file = iwd / (name1 + doy + '0.' + yy + 'D') # pathlib Path class
-    crx2file = iwd / (name2 + doy + '0.' + yy + 'D') # pathlib Path class
+    rnx1file = Path(iwd +os.sep + (name1 + doy + '0.' + yy + 'O')) # pathlib Path class
+    rnx2file = Path(iwd +os.sep + (name2 + doy + '0.' + yy + 'O')) # pathlib Path class
+    crx1file = Path(iwd +os.sep + (name1 + doy + '0.' + yy + 'D')) # pathlib Path class
+    crx2file = Path(iwd +os.sep + (name2 + doy + '0.' + yy + 'D')) # pathlib Path class
     
+ 
     # Check if there is a need for hatanaka decompression for LEO 1.
     if rnx1file.exists():
         print('Decompressed RINEX obs file observed for ' + name1 + '\n')


### PR DESCRIPTION
Issue: Saving to 1 input and 1 output clutters the folder environment

Proposed solution: With 1 campaign name, save input and outputs like so
input                                               output
   |                                                       |
   |                                                       |
campaign name                            campaign name

Note: I'm not sure if this is most efficient. Maybe making the "campaign name" the parent folder instead of child folder would be easier. Following the Bernese campaign file hierarchy? In that case changes are only repositioning the directory names in gpsxtr.py, leorun.py, leogui.py, pubplt.py and rnpath.py
